### PR TITLE
cmm: return failure for rejected QM commands

### DIFF
--- a/cmm/src/client_daemon.c
+++ b/cmm/src/client_daemon.c
@@ -429,7 +429,7 @@ int cmmClientProcessCmd(char * command, int argc, char ** argv, daemon_handle_t 
 		{
 			/*Call QM process function*/
 			if(cmmQmSetProcess(keywords, 2, daemon_handle))
-				return -1;
+				return CMM_CLIENT_EXIT_FAIL;
 		}
 		else if (strcasecmp(keywords[1], "mc6") == 0)
 		{
@@ -766,9 +766,7 @@ help:
  *      cmm client main function
  *
  *****************************************************************/
-/* qm-config opts into exit-code reporting (see CMM_CLIENT_EXIT_FAIL): a
- * reload that never reaches the daemon must fail, not silently exit 0. Match
- * the whole first token of the raw "-c" string so "qm-configXYZ" does not. */
+/* QM commands opt into exit-code reporting (see CMM_CLIENT_EXIT_FAIL). */
 static int cmmClientDaemonDownRc(const char *command)
 {
 	/* Mirror the dispatch's tokenization (strtok on ' '): skip leading
@@ -778,6 +776,9 @@ static int cmmClientDaemonDownRc(const char *command)
 			command++;
 		if (strncasecmp(command, "qm-config", 9) == 0 &&
 				(command[9] == '\0' || command[9] == ' '))
+			return CMM_CLIENT_EXIT_FAIL;
+		if (strncasecmp(command, "set qm", 6) == 0 &&
+				(command[6] == '\0' || command[6] == ' '))
 			return CMM_CLIENT_EXIT_FAIL;
 	}
 	return -1;

--- a/cmm/src/client_daemon.h
+++ b/cmm/src/client_daemon.h
@@ -43,7 +43,7 @@ static inline u_int32_t testbit_in_array(u_int8_t *pbits, u_int32_t bitindex)
  * process-exit-code propagation: cmm.c maps ONLY this to a nonzero exit. A
  * plain -1 (usage/help/other command errors) keeps the historical "cmm -c
  * always exits 0" behaviour, so exit-code reporting stays limited to the
- * commands that ask for it (currently qm-config). */
+ * commands that ask for it (qm-config and set qm). */
 #define CMM_CLIENT_EXIT_FAIL		(2)
 
 	int cmmClient(char * command, int argc, char **argv);

--- a/cmm/src/cmm.c
+++ b/cmm/src/cmm.c
@@ -386,7 +386,7 @@ int main (int argc, char ** argv)
 			case 'c':	// Launch cmm as a client communicating with the cmm daemon
 				/* Historically -c always exited 0. Keep that for every
 				 * subcommand except those that opt in by returning
-				 * CMM_CLIENT_EXIT_FAIL (currently qm-config), so a caller
+				 * CMM_CLIENT_EXIT_FAIL, so a caller
 				 * can detect a bad reload without changing any other
 				 * command's exit-code ABI. */
 				return cmmClient(optarg, argc-optind, &argv[optind])

--- a/cmm/src/module_qm.c
+++ b/cmm/src/module_qm.c
@@ -586,8 +586,7 @@ void cmmQmSetPrintHelp(void)
  * Only the set path (the "if (cmmQmSend(...) == 2)" sites) routes through
  * cmmQmSend; the query handlers keep calling cmmSendToDaemon directly since
  * they are never dry-run and inspect their own replies. FPP reply status is
- * left to each handler (they already log/tolerate it as they see fit) -- the
- * wrapper does not reinterpret it as a command failure.
+ * logged by each handler. The wrapper also records rejected writes.
  *
  * Defined outside the LS1043 guard because both cmmQmSetProcess variants
  * route their sends through cmmQmSend, and it only depends on the
@@ -599,13 +598,19 @@ void cmmQmSetPrintHelp(void)
  * "cmm -c" is a one-shot client, so this holds.
  */
 static int cmmQmValidateOnly;
+static int cmmQmCommandFailed;
 
 static int cmmQmSend(daemon_handle_t daemon_handle, unsigned short cmd,
 		void *snd, int sz, void *rcv)
 {
+	int rc;
+
 	if (cmmQmValidateOnly)
 		return 0;	/* != 2: the caller's "== 2" result check is skipped */
-	return cmmSendToDaemon(daemon_handle, cmd, snd, sz, rcv);
+	rc = cmmSendToDaemon(daemon_handle, cmd, snd, sz, rcv);
+	if (rc < (int)sizeof(unsigned short) || cmmDaemonCmdRC(rcv) != 0)
+		cmmQmCommandFailed = 1;
+	return rc;
 }
 
 #ifdef LS1043
@@ -1558,6 +1563,7 @@ int cmmQmSetProcess(char **keywords, int tabStart, daemon_handle_t daemon_handle
 	int cpt;
 	int retval;
 
+	cmmQmCommandFailed = 0;
 	cpt = tabStart;
 	if (!keywords[cpt])  {
 		retval = QM_ERROR;
@@ -1619,10 +1625,7 @@ err_ret:
 			cmmQmSetPrintHelp();
 			break;
 		default:
-			/* parsed OK (0 in validate-only mode too, where nothing was
-			 * sent). FPP reply status is handled per-directive by the
-			 * sub-handlers, not reinterpreted here. */
-			return 0;
+			return cmmQmCommandFailed ? -1 : 0;
 	}
 	return -1;
 }
@@ -1673,7 +1676,7 @@ err_ret:
  *      intentionally not inspected.
  *   3. APPLY -- each directive is applied through cmmQmSetProcess (the FPP
  *      protocol is not reimplemented). Per-directive FPP reply status is
- *      logged by the handlers, exactly as an interactive "set qm" would.
+ *      logged by the handlers and returned to the caller.
  *
  * Not atomic: phase 2 flushes before phase 3 re-applies, so there is a brief
  * window where egress QoS is cleared. <file> is read once up front so
@@ -1683,9 +1686,7 @@ err_ret:
  *
  * Reachable from the live CLI ("qm-config <file>") and "cmm -c 'qm-config
  * <file>'". Returns 0 once a validated file is flushed and applied; returns
- * -1 (a nonzero exit under "cmm -c") on a validation or I/O failure -- a file
- * that could not be accepted, not a runtime fast-path rejection of a single
- * directive.
+ * -1 (a nonzero exit under "cmm -c") on a validation, I/O, or FPP failure.
  *****************************************************************/
 #define QM_RELOAD_LINE_MAX	512
 #define QM_RELOAD_MAX_TOKENS	64
@@ -1882,13 +1883,8 @@ int cmmQmConfigReload(const char *path, daemon_handle_t daemon_handle)
 	/* Phase 2: flush current QoS/shaper state (validated file). */
 	cmmQmReloadFlush(daemon_handle);
 
-	/* Phase 3: apply. Every directive already passed the identical parse in
-	 * phase 1 (same bytes, same parser), so cmmQmSetProcess re-parses cleanly
-	 * and its return conveys nothing new. Per-directive FPP reply status is
-	 * logged by the handlers, exactly as an interactive "set qm" would; it is
-	 * not reflected in the reload's result. The exit code therefore reports a
-	 * rejected file (validation) or an I/O error, not a runtime fast-path
-	 * rejection of an individual directive. */
+	/* Phase 3: apply. Stop and report an FPP rejection. The reset has already
+	 * happened, so the caller must not treat a partial apply as success. */
 	lineno = 0;
 	for (p = buf; p < end; ) {
 		p = cmmQmReloadNextLine(p, end, scratch, sizeof(scratch), &overlong);
@@ -1896,7 +1892,12 @@ int cmmQmConfigReload(const char *path, daemon_handle_t daemon_handle)
 		n = cmmQmReloadTokenize(scratch, kw);
 		if (n == 0)
 			continue;
-		cmmQmSetProcess(kw, 2, daemon_handle);
+		if (cmmQmSetProcess(kw, 2, daemon_handle) != 0) {
+			cmm_print(DEBUG_CRIT, "qm-config: %s:%d: FPP rejected directive\n",
+					path, lineno);
+			free(buf);
+			return -1;
+		}
 	}
 	free(buf);
 


### PR DESCRIPTION
## Summary

- propagate FPP QM command failures through the CMM client exit status
- return failure when `set qm` parsing or execution fails
- return failure when `qm-config` rejects a directive during apply

## Validation

- built the complete Mono Gateway OpenWrt firmware with this ASK commit
- flashed and booted the image on a Mono Gateway Development Kit
- confirmed a duplicate channel assignment is rejected with exit status 1 instead of 0
- confirmed `cmmqos reload` returns 0 and does not repeat the one-time channel assignment
- confirmed the configured upload rate is enforced on live traffic

Related: we-are-mono/openwrt#7